### PR TITLE
Change case_id to test_id in XmlReportWriter.java

### DIFF
--- a/src/main/java/com/testrail/junit/customjunitxml/XmlReportWriter.java
+++ b/src/main/java/com/testrail/junit/customjunitxml/XmlReportWriter.java
@@ -261,13 +261,13 @@ class XmlReportWriter {
 		}
 
 		Optional<TestRail> testRailTest = AnnotationSupport.findAnnotation(testMethod, TestRail.class);
-		String case_id = null;
+		String test_id = null;
 		String test_summary = null;
 		String test_description = null;
 		if (testRailTest.isPresent()) {
-			case_id = testRailTest.get().id();
-			if ((case_id != null) && (!case_id.isEmpty())) {
-				addProperty(writer, "case_id", case_id);
+			test_id = testRailTest.get().id();
+			if ((test_id != null) && (!test_id.isEmpty())) {
+				addProperty(writer, "test_id", test_id);
 			}
 
 			test_summary = testRailTest.get().summary();


### PR DESCRIPTION
According to https://support.testrail.com/hc/en-us/articles/12609869124116-Automation-workflows-Specification-first#mapping-test-cases-0-1, TestRail parses "test_id" key, but not "case_id".