### PR TITLE
encode newline, carriage return and tab chars on value attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.testrail</groupId>
     <artifactId>testrail-junit-extensions</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <name>testrail-junit-extensions</name>
     <description>Improvements for JUnit that allow you to take better advantage of JUnit 5 (jupiter engine)</description>
     <url>https://github.com/gurock/testrail-junit-extensions</url>

--- a/src/main/java/com/testrail/junit/customjunitxml/XmlReportWriter.java
+++ b/src/main/java/com/testrail/junit/customjunitxml/XmlReportWriter.java
@@ -126,6 +126,7 @@ class XmlReportWriter {
 			Writer out) throws XMLStreamException {
 
 		XMLOutputFactory factory = XMLOutputFactory.newInstance();
+		factory.setProperty("escapeCharacters", false);
 		XMLStreamWriter xmlWriter = factory.createXMLStreamWriter(out);
 		xmlWriter.writeStartDocument("UTF-8", "1.0");
 		newLine(xmlWriter);
@@ -318,9 +319,7 @@ class XmlReportWriter {
 
 
 	private void addPropertyAndEscapeValue(XMLStreamWriter writer, String name, String value) throws XMLStreamException {
-		writer.writeEmptyElement("property");
-		writeAttributeSafely(writer, "name", name);
-		writeAttributeSafelyEncodingSomeChars(writer, "value", value);
+		writer.writeCharacters(String.format("<property name=\"%s\" value=\"%s\"/>", name, escapeIllegalCharsForAttributes(value)));
 		newLine(writer);
 	}
 

--- a/src/test/java/com/testrail/junit/customjunitxml/EnhancedLegacyXmlTest.java
+++ b/src/test/java/com/testrail/junit/customjunitxml/EnhancedLegacyXmlTest.java
@@ -378,6 +378,17 @@ public class EnhancedLegacyXmlTest {
         assertThat(testcase.child("properties").children("property").matchAttr("name", "my_property2").attr("value")).isEqualTo("world");
     }
 
+    @Test
+    public void shouldStoreMultilineTestRunProperties() throws Exception {
+        String testMethodName = "testWithTestRunPropertyMultiline";
+        executeTestMethodWithParams(TEST_EXAMPLES_CLASS, testMethodName, "com.testrail.junit.customjunitxml.TestRailTestReporter");
+        dumpJunitXMLReport(tempDirectory.resolve(REPORT_NAME));
+        Match testsuite = readValidXmlFile(tempDirectory.resolve(REPORT_NAME));
+        Match testcase = testsuite.child("testcase");
+        assertThat(testcase.attr("name", String.class)).isEqualTo(testMethodName);
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "testrail_case_field").attr("value")).isEqualTo("custom_steps:1. First step&#10;2. Second step&#10;3. Third step");
+    }
+
 	private Match readValidXmlFile(Path xmlFile) throws Exception {
 		assertTrue(Files.exists(xmlFile), () -> "File does not exist: " + xmlFile);
 		try (BufferedReader reader = Files.newBufferedReader(xmlFile)) {
@@ -397,6 +408,15 @@ public class EnhancedLegacyXmlTest {
 			fail("Invalid XML document: " + document, e);
 		}
 	}
+
+    private void dumpJunitXMLReport(Path reportPath) {
+        System.out.println("Junit XML report: " + reportPath);
+        try {
+            Files.lines(reportPath).forEach(System.out::println);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
 	private enum CachedSchema {
 

--- a/src/test/java/com/testrail/junit/customjunitxml/EnhancedLegacyXmlTest.java
+++ b/src/test/java/com/testrail/junit/customjunitxml/EnhancedLegacyXmlTest.java
@@ -382,7 +382,6 @@ public class EnhancedLegacyXmlTest {
     public void shouldStoreMultilineTestRunProperties() throws Exception {
         String testMethodName = "testWithTestRunPropertyMultiline";
         executeTestMethodWithParams(TEST_EXAMPLES_CLASS, testMethodName, "com.testrail.junit.customjunitxml.TestRailTestReporter");
-        dumpJunitXMLReport(tempDirectory.resolve(REPORT_NAME));
         Match testsuite = readValidXmlFile(tempDirectory.resolve(REPORT_NAME));
         Match testcase = testsuite.child("testcase");
         assertThat(testcase.attr("name", String.class)).isEqualTo(testMethodName);

--- a/src/test/java/com/testrail/junit/customjunitxml/EnhancedLegacyXmlTest.java
+++ b/src/test/java/com/testrail/junit/customjunitxml/EnhancedLegacyXmlTest.java
@@ -14,6 +14,7 @@ package com.testrail.junit.customjunitxml;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.joox.JOOX.$;
+import static org.joox.JOOX.attr;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectMethod;
@@ -385,7 +386,7 @@ public class EnhancedLegacyXmlTest {
         Match testsuite = readValidXmlFile(tempDirectory.resolve(REPORT_NAME));
         Match testcase = testsuite.child("testcase");
         assertThat(testcase.attr("name", String.class)).isEqualTo(testMethodName);
-        assertThat(testcase.child("properties").children("property").matchAttr("name", "testrail_case_field").attr("value")).isEqualTo("custom_steps:1. First step&#10;2. Second step&#10;3. Third step");
+        assertThat(testcase.child("properties").children("property").matchAttr("name", "testrail_case_field").attr("value")).isEqualTo("custom_steps:1. First step\n2. Second step\n3. Third step");
     }
 
 	private Match readValidXmlFile(Path xmlFile) throws Exception {

--- a/src/test/java/com/testrail/junit/customjunitxml/ExamplesTestRailEnabledTestExamples.java
+++ b/src/test/java/com/testrail/junit/customjunitxml/ExamplesTestRailEnabledTestExamples.java
@@ -40,6 +40,12 @@ public class ExamplesTestRailEnabledTestExamples {
     }
 
     @Test
+    public void testWithTestRunPropertyMultiline(TestRailTestReporter customReporter) {
+        customReporter.setProperty("testrail_case_field", "custom_steps:1. First step\n2. Second step\n3. Third step");
+    }
+
+
+    @Test
     @TestRail(id = "myCustomId")
     public void annotatedTestWithCustomId() {
         fail("this should have id: myCustomId");


### PR DESCRIPTION
This is a workaround to deal with some parsers that struggle parsing "value" attribute of properties that can have newline characters for example.
It should not break any parsers out there but we'll need to track this from here onwards. 

Addresses #6 