### PR TITLE
fix #9 and add support for encoding properties using cdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add the following dependency to your pom.xml:
 <dependency>
   <groupId>com.testrail</groupId>
   <artifactId>testrail-junit-extensions</artifactId>
-  <version>0.1.1</version>
+  <version>0.2.0</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -53,13 +53,15 @@ If you want, you may configure certain aspects of this extension. The defaults s
 - `report_filename`: the name of the report, without ending .xml suffix. Default is "TEST-junit-jupiter.xml"
 - `report_directory`: the directory where to generate the report, in relative or absolute format. Default is "target"
 - `add_timestamp_to_report_filename`: the name of the report, without ending .xml suffix. Default is "false".
-
+- `properties_using_cdata`: list of properties, delimited by comma, whose content should be encoded as cdata inner content instead of `value` attribute on the `property` element; by default "testrail_case_field" is encoded as cdata. This is useful whenever you want to add properties that have newlines and other characters as part of their content. (encoding as cdata is only supported by TR CLI v1.9.3+)
+ 
 Example:
 
 ```bash
 report_filename=custom-report-junit
 report_directory=reports
 add_timestamp_to_report_filename=true
+properties_using_cdata=testrail_case_field
 ```
 
 ## How to use

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.testrail</groupId>
     <artifactId>testrail-junit-extensions</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.2</version>
+    <version>0.2.0</version>
     <name>testrail-junit-extensions</name>
     <description>Improvements for JUnit that allow you to take better advantage of JUnit 5 (jupiter engine)</description>
     <url>https://github.com/gurock/testrail-junit-extensions</url>

--- a/src/main/java/com/testrail/junit/customjunitxml/EnhancedLegacyXmlReportGeneratingListener.java
+++ b/src/main/java/com/testrail/junit/customjunitxml/EnhancedLegacyXmlReportGeneratingListener.java
@@ -60,6 +60,7 @@ public class EnhancedLegacyXmlReportGeneratingListener implements TestExecutionL
 
 	private String reportFilename = null;
 	boolean addTimestampToReportFilename = false;
+	String [] testrailPropertiesUsingCData = { "testrail_case_field" };
 
 	private XmlReportData reportData;
 
@@ -97,6 +98,10 @@ public class EnhancedLegacyXmlReportGeneratingListener implements TestExecutionL
 					this.reportsDir = FileSystems.getDefault().getPath(customReportsDirectory);
 				}
 				this.addTimestampToReportFilename = "true".equals(properties.getProperty("add_timestamp_to_report_filename"));
+				String propertiesUsingCdata = properties.getProperty("properties_using_cdata");
+				if (propertiesUsingCdata != null) {
+					this.testrailPropertiesUsingCData = propertiesUsingCdata.split((","));
+				}
 			} else {
 				if (reportsDir == null) {
 					this.reportsDir = FileSystems.getDefault().getPath(DEFAULT_REPORTS_DIR);
@@ -180,7 +185,7 @@ public class EnhancedLegacyXmlReportGeneratingListener implements TestExecutionL
 		xmlFile = this.reportsDir.resolve(fileName);
 
 		try (Writer fileWriter = Files.newBufferedWriter(xmlFile)) {
-			new XmlReportWriter(this.reportData).writeXmlReport(testIdentifier, fileWriter);
+			new XmlReportWriter(this.reportData, this.testrailPropertiesUsingCData).writeXmlReport(testIdentifier, fileWriter);
 		} catch (XMLStreamException | IOException e) {
 			printException("Could not write XML report: " + xmlFile, e);
 			logger.error(e, () -> "Could not write XML report: " + xmlFile);

--- a/src/test/java/com/testrail/junit/customjunitxml/ExamplesTestRailEnabledTestExamples.java
+++ b/src/test/java/com/testrail/junit/customjunitxml/ExamplesTestRailEnabledTestExamples.java
@@ -34,16 +34,25 @@ public class ExamplesTestRailEnabledTestExamples {
     }
 
     @Test
+    public void testWithTestRunPropertyWithSpecialCharsInValue(TestRailTestReporter customReporter) {
+        customReporter.setProperty("testrail_result_comment", "testing:&&qS55!T@");
+    }
+
+    @Test
     public void testWithMultipleTestRunProperties(TestRailTestReporter customReporter) {
         customReporter.setProperty("my_property1", "hello");
         customReporter.setProperty("my_property2", "world");
     }
 
     @Test
-    public void testWithTestRunPropertyMultiline(TestRailTestReporter customReporter) {
+    public void testWithDefaultMultilineProperty(TestRailTestReporter customReporter) {
         customReporter.setProperty("testrail_case_field", "custom_steps:1. First step\n2. Second step\n3. Third step");
     }
 
+    @Test
+    public void testWithCustomMultilineProperty(TestRailTestReporter customReporter) {
+        customReporter.setProperty("multiline_property", "1. First step\n2. Second step\n3. Third step");
+    }
 
     @Test
     @TestRail(id = "myCustomId")


### PR DESCRIPTION
- fixes #9 
- adds support for configuring which properties should use cdata instead of `value` attribute on the  `<property>`  element on the JUnit XML report