### PR TITLE
Bug/issue12 fix property generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add the following dependency to your pom.xml:
 <dependency>
   <groupId>com.testrail</groupId>
   <artifactId>testrail-junit-extensions</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -70,10 +70,10 @@ properties_using_cdata=testrail_case_field
 
 In order to generate the enhanced, customized JUnit XML report we need to register the **EnhancedLegacyXmlReportGeneratingListener** listener. This can be done in [several ways](https://junit.org/junit5/docs/current/user-guide/#launcher-api-listeners-custom):
 
-- discovered automatically at runtime based on the contents of a file (e.g `src/test/META-INF/services/org.junit.platform.launcher.TestExecutionListener`) 
+- discovered automatically at runtime based on the contents of a file (e.g `src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener`) 
 
 ```
-EnhancedLegacyXmlReportGeneratingListener
+com.testrail.junit.customjunitxml.EnhancedLegacyXmlReportGeneratingListener
 ```
 
 - programmaticaly

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,8 @@
     </scm>
 
     <properties>
-        <junit-jupiter.version>5.7.1</junit-jupiter.version>
-        <junit.version>4.13.2</junit.version>
-        <junit-platform.version>1.7.1</junit-platform.version>
-        <slf4j-log4j12.version>1.7.25</slf4j-log4j12.version>
+        <junit-jupiter.version>5.11.4</junit-jupiter.version>
+        <junit-platform.version>1.11.4</junit-platform.version>
         <version.maven-plugin-plugin>3.6.0</version.maven-plugin-plugin>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     </properties>
@@ -87,6 +85,7 @@
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
             <version>${junit-platform.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
@@ -142,6 +141,7 @@
         
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.9.0</version>
                 <configuration>
                     <debug>true</debug>
                     <source>1.8</source>


### PR DESCRIPTION
I am working with @cgeisel on his issue https://github.com/gurock/testrail-junit-extensions/issues/12.

I corrected the README documentation:
- the `META-INF` has to go in the `resources` folder in order to get properly built into the project.
- the `EnhancedLegacyXmlReportGeneratingListener` needs to have a fully-qualified-name in order to be found by the listener.

I corrected the POM:
- the `junit-platform-runner` brings in transitive dependency on JUnit4, which messes up surefire when discovering which runner to use; details are in this [SO post](https://stackoverflow.com/a/77847900/3124333).
- updated the Jupiter dependency versions to latest as there was issues finding my tests; details are in this [SO post](https://stackoverflow.com/a/70808876/3124333).

I am pretty certain that the POM can be cleaned up further - most of the dependencies are not used, but I did not remove them for fear of breaking things. As per your POM, when more tests are added it will be easier to clean things up.